### PR TITLE
Use textbuttons for vocabulary hover tooltips

### DIFF
--- a/game/script.rpy
+++ b/game/script.rpy
@@ -41,56 +41,13 @@ define vocabulary = {
     "葬禮": "funeral"
 }
 
-# ------------- 高亮函式 ---------------
-init python:
-    def tag_vocab(text):
-        """
-        將句子中的詞彙替換為超連結 + 金色底線。
-        使用標記位置方法避免重疊。
-        """
-        if not text:
-            return text
-            
-        # 找到所有詞彙的位置
-        matches = []
-        for word in vocabulary.keys():
-            start = 0
-            while True:
-                pos = text.find(word, start)
-                if pos == -1:
-                    break
-                matches.append((pos, pos + len(word), word))
-                start = pos + 1
-        
-        # 按位置排序，移除重疊
-        matches.sort()
-        filtered_matches = []
-        for start, end, word in matches:
-            # 檢查是否與已有匹配重疊
-            overlap = False
-            for existing_start, existing_end, existing_word in filtered_matches:
-                if not (end <= existing_start or start >= existing_end):
-                    overlap = True
-                    break
-            if not overlap:
-                filtered_matches.append((start, end, word))
-        
-        # 從後往前替換，避免位置偏移
-        filtered_matches.reverse()
-        result = text
-        for start, end, word in filtered_matches:
-            replacement = "{a=vocab:" + word + "}{color=#ffcc66}{u}" + word + "{/u}{/color}{/a}"
-            result = result[:start] + replacement + result[end:]
-        
-        return result
-
 # Python 處理函數
 init python:
     # 全域變數
-    current_display_text = text
+    current_display_text = ""
     current_chapter = 1
 
-    # 文字處理函數 - 使用高亮機制
+    # 文字處理函數
     def set_story_text(text):
         global current_display_text
         current_display_text = text
@@ -100,35 +57,25 @@ init python:
 
     def previous_chapter():
         renpy.jump("ch1_start")
-
-    # 點擊詞彙顯示 Tooltip（必要）
-    config.hyperlink_handlers["vocab"] = lambda link: renpy.show_screen(
-        "vocab_tooltip",
-        word=link.split(":")[-1] if link else ""
-    )
 # 聲明遊戲角色
 define narrator = Character(None, what_color="#ffffff")
 define albert = Character("亞伯特", color="#87ceeb")
 
 # 詞彙提示框 - 懸浮版本
 screen vocab_tooltip(word):
-    modal True
-    key "game_menu" action Hide("vocab_tooltip")  # 右鍵關閉
-    
     if word in vocabulary:
         frame:
             xalign 0.85 yalign 0.5
             padding (20, 15)
             background "#1a1a1aee"
-            
+
             vbox:
                 spacing 5
                 text "詞彙解釋" size 14 color "#888888"
                 text word size 18 color "#ffcc66" bold True
-                text "▼" size 12 color "#888888"  
+                text "▼" size 12 color "#888888"
                 text vocabulary[word] size 16 color "#87ceeb"
                 null height 10
-                textbutton "關閉" action Hide("vocab_tooltip") text_size 14
 
 # 故事顯示介面 - 修正點擊邏輯並加入懸浮功能
 screen story_main():
@@ -138,7 +85,7 @@ screen story_main():
     # 鍵盤行為：左鍵/空白/Enter 前進；右鍵/Esc 無動作
     key "dismiss" action Return()
     key "game_menu" action NullAction()
-        # 右上角導航（維持既有行為，不改 label 名）
+    # 右上角導航（維持既有行為，不改 label 名）
     hbox:
         xalign 0.95 yalign 0.05
         spacing 10

--- a/game/ui_vocab.rpy
+++ b/game/ui_vocab.rpy
@@ -1,34 +1,23 @@
-﻿# game/ui_vocab.rpy
-# 將一句文字拆成「一般片段」與「詞彙片段」，詞彙片段以 textbutton 呈現，hover/點擊顯示 tooltip。
-# 不依賴 config.hyperlink_focus/leave，穩定支援 Ren'Py 8.x。
+# game/ui_vocab.rpy
+# Splits text into normal and vocabulary segments, displaying vocab segments as textbuttons.
+# Hover or click shows tooltip. Works with Ren'Py 8.3.x without hyperlink config.
 
 init python:
-    # 取得詞彙鍵值，若尚未定義 vocabulary 也不會炸
     try:
         _VOCAB_KEYS = list(vocabulary.keys())
-        # 長詞優先，避免「戰壕」被「戰」先吃掉
-        _VOCAB_KEYS.sort(key=len, reverse=True)
+        _VOCAB_KEYS.sort(key=len, reverse=True)  # Longer words first
     except Exception:
         _VOCAB_KEYS = []
 
     def _split_line_by_vocab(line):
-        """
-        將單行字串拆成 segments：
-        segment = {"text": <文字>, "is_vocab": True/False}
-        用最左優先、同起點取最長詞的策略，避免重疊與亂序。
-        """
         if not line:
             return [{"text": "", "is_vocab": False}]
-
         segments = []
         i = 0
         n = len(line)
-
         while i < n:
             earliest_pos = None
             chosen_word = None
-
-            # 找從 i 起最早出現的詞，若有多個同位置，取最長
             for w in _VOCAB_KEYS:
                 pos = line.find(w, i)
                 if pos == -1:
@@ -36,30 +25,23 @@ init python:
                 if (earliest_pos is None) or (pos < earliest_pos) or (pos == earliest_pos and len(w) > len(chosen_word or "")):
                     earliest_pos = pos
                     chosen_word = w
-
             if earliest_pos is None:
-                # 後面都是一般文字
                 segments.append({"text": line[i:], "is_vocab": False})
                 break
-
-            # 先加一般文字
             if earliest_pos > i:
                 segments.append({"text": line[i:earliest_pos], "is_vocab": False})
-
-            # 再加詞彙片段
             segments.append({"text": chosen_word, "is_vocab": True})
             i = earliest_pos + len(chosen_word)
-
         return segments
 
 screen vocab_textbox(display_text):
-    # 文字框：1000x220、黑底 80% 透明、字 22px（按需求）
+    default tt = Tooltip(None)
+
     frame:
         xalign 0.5 yalign 0.85
         xsize 1000 ysize 220
         background "#000000cc"
         padding (40, 25)
-
         vbox:
             spacing 6
             for _line in (display_text or "").split("\n"):
@@ -69,15 +51,16 @@ screen vocab_textbox(display_text):
                     for seg in _segments:
                         if seg["is_vocab"]:
                             textbutton seg["text"]:
-                                action NullAction()
+                                action tt.Action(seg["text"])
                                 background None
                                 padding (0, 0)
-                                # 金色 + 滑過變白
                                 text_color "#ffcc66"
                                 text_hover_color "#ffffff"
                                 text_size 22
-                                # 懸浮顯示詞彙 tooltip；移開就關閉
-                                hovered Show("vocab_tooltip", word=seg["text"])
-                                unhovered Hide("vocab_tooltip")
+                                hovered tt.Action(seg["text"])
+                                unhovered tt.Action(None)
                         else:
                             text seg["text"] size 22 color "#ffffff"
+
+    if tt.value:
+        use vocab_tooltip(tt.value)


### PR DESCRIPTION
## Summary
- Replaced Show/Hide actions with a Tooltip-based textbutton system so hovering or clicking vocabulary words displays their translations.
- Simplified `vocab_tooltip` to a non-modal overlay that is shown within the textbox and dismisses automatically when the pointer leaves a word.

## Testing
- `python -m py_compile game/ui_vocab.rpy game/script.rpy` *(fails: SyntaxError: invalid syntax)*
- `pip install renpy==8.3.7.25031702` *(fails: Could not find a version that satisfies the requirement renpy==8.3.7.25031702; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689aa1a2ed248332bb1f5f94725c3b11